### PR TITLE
Namespaces should be included with http://

### DIFF
--- a/Resources/Private/Templates/Page/NewPagetree.html
+++ b/Resources/Private/Templates/Page/NewPagetree.html
@@ -1,6 +1,6 @@
 <html
-    xmlns:core="https://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
-    xmlns:be="https://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
+    xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
+    xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
     data-namespace-typo3-fluid="true"
 >
 


### PR DESCRIPTION
Fluid namespaces should be included with http:// instead of https://. Otherwise the TemplateParser won't resolve the namespace correctly. (at least in my case I get a UnknownNamespaceException using the extension)